### PR TITLE
Fix development shell on `master`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,4 +3,4 @@ if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
 fi
 # https://github.com/input-output-hk/devx Slightly opinionated shared GitHub Action for Cardano-Haskell projects
-use flake "github:input-output-hk/devx#ghc964-iog"
+use flake "github:input-output-hk/devx?rev=6ee20d669c3a3823c5add1e1528818ccff1eb2b9#ghc96-iog"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
         "Fracada",
         "POCRE",
         "Serialised"
-    ]
+    ],
+    "haskell.manageHLS": "PATH"
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Arch Linux has `libblst` in AUR, nix are exemplified by IOHK,
 and manual installation is described here:
 https://github.com/input-output-hk/cardano-node-wiki/blob/main/docs/getting-started/install.md#installing-blst
 
+Make sure to `cabal update` before building.
+
+The project uses `github:input-output-hk/devx` to make the development shell. See `.envrc` for details.
+
 ## Running tests
 
 Tests are runned in emulated environment by default.


### PR DESCRIPTION
Dev shell on master is currently not working due to the non-backward-compatible devx version update. The version has not been explicitly specified in `.envrc` which caused a dev shell to  attempt to use newer version and fail.
This PR pinpoints the devx version to make sure updates do not break the dev shell.